### PR TITLE
Support multiple mu plugins packages

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -50,6 +50,8 @@ final class Config implements \ArrayAccess
     public const DEV_PATHS_YAML_CONFIG_DIR_KEY = 'config-dir';
     public const DEV_PATHS_PRIVATE_DIR_KEY = 'private-dir';
 
+    public const PACKAGE_TYPE_MULTIPLE_MU_PLUGINS = 'wordpress-multiple-mu-plugins';
+
     public const DEFAULTS = [
         self::VIP_CONFIG_KEY => [
             self::VIP_LOCAL_DIR_KEY => 'vip',

--- a/src/Task/Factory.php
+++ b/src/Task/Factory.php
@@ -75,6 +75,7 @@ class Factory
             CopyDevPaths::class,
             function (): CopyDevPaths {
                 return new CopyDevPaths(
+                    $this->factory->composer(),
                     $this->factory->config(),
                     $this->factory->vipDirectories(),
                     $this->factory->filesystem()


### PR DESCRIPTION
The command `--sync-dev-paths` now supports also the multiple mu-plugins packages. Alongside other copying, it checks if packages of this type exist, if so, it copies their content in the proper mu-plugins folder.

I add some comments below to explain my latest doubts.