### PR TITLE
Remove restriction to copy only files in "mu-plugins" and "images"-folder

### DIFF
--- a/src/Task/CopyDevPaths.php
+++ b/src/Task/CopyDevPaths.php
@@ -184,7 +184,7 @@ final class CopyDevPaths implements Task
             case Config::DEV_PATHS_MUPLUGINS_DIR_KEY:
                 $what = 'MU plugins';
                 $target = $this->directories->muPluginsDir();
-                $finder and $finder->files()->ignoreDotFiles(true);
+                $finder and $finder->ignoreDotFiles(true);
                 break;
             case Config::DEV_PATHS_PLUGINS_DIR_KEY:
                 $what = 'Plugins';
@@ -208,7 +208,7 @@ final class CopyDevPaths implements Task
             case Config::DEV_PATHS_IMAGES_DIR_KEY:
                 $what = 'Images';
                 $target = $this->directories->imagesDir();
-                $finder and $finder->files()->ignoreDotFiles(true);
+                $finder and $finder->ignoreDotFiles(true);
                 break;
             case Config::DEV_PATHS_PHP_CONFIG_DIR_KEY:
                 $what = 'PHP config files';


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] Docs have been added/updated (for bug fixes/features)
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This pull request removes the restriction to only copy files in root from `mu-plugins`- and `images`-folder into the `vip`-folder. We shouldn't restrict here and also allow support for folders within those directories to be copied.

* **What is the current behavior?** (You can also link to an open issue here)

For both folders currently only files at root level are copied into `vip`-folder.

* **What is the new behavior (if this is a feature change)?**

With this change also files and folders within `mu-plugins` and `images` are copied into `vip`.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

Nope.


* **Other information**:

I've have not updated Docs yet. Don't know if it is neccesary to have a list of restrictions/possiblities. This might will change in future again and will provide no benefit to be documented. Basically "everything" is being copied within those folders.

We might also should consider following in future (new issues):

*Languages:*
- Also remove restriction to only files in root-folder.
- Add support for `.json` (Gutenberg translation files).

*Images:*
- Maybe restrict to actualy image formats, since the folder is called _images_  and not _everything is possible_. :) 