### PR TITLE
SymlinkVipGoDir - various fixes and improvments on run method

### DIFF
--- a/psalm.xml
+++ b/psalm.xml
@@ -26,5 +26,6 @@
         <MissingClosureReturnType errorLevel="suppress" />
         <UnresolvableInclude errorLevel="suppress" />
         <UndefinedConstant errorLevel="suppress" />
+        <UnnecessaryVarAnnotation errorLevel="suppress" />
     </issueHandlers>
 </psalm>

--- a/src/Command.php
+++ b/src/Command.php
@@ -194,11 +194,6 @@ class Command extends BaseCommand
     private function createConfig(InputInterface $input): Task\TaskConfig
     {
         $options = [];
-        /**
-         * @var string $key
-         * @var string $taskKey
-         * @var bool $default
-         */
         foreach (self::OPTIONS as $key => [$taskKey, $default]) {
             $options[$taskKey] = $this->optionValue($input, $key, $default);
         }

--- a/src/Git/VipGit.php
+++ b/src/Git/VipGit.php
@@ -344,7 +344,6 @@ class VipGit
         }
 
         $this->io->commentLine("Pushing to <<<{$remoteUrl}>>>");
-        /** @var bool $success */
         [$success] = $this->git->exec('push origin');
 
         return $success;

--- a/src/Task/EnsureGitKeep.php
+++ b/src/Task/EnsureGitKeep.php
@@ -124,7 +124,7 @@ final class EnsureGitKeep implements Task
             ->ignoreDotFiles(false)
             ->ignoreVCS(false)
             ->filter(
-                static function (SplFileInfo $info) use ($dir, $depth): bool {
+                static function (SplFileInfo $info) use ($depth): bool {
                     return $depth > 0 || $info->getBasename() !== '.gitkeep';
                 }
             );

--- a/src/Task/SymlinkVipGoDir.php
+++ b/src/Task/SymlinkVipGoDir.php
@@ -102,9 +102,7 @@ final class SymlinkVipGoDir implements Task
                 continue;
             }
 
-            if (!$this->filesystem->relativeSymlink($target, $link)) {
-                $io->errorLine("Failed creating relative symlink for {$link} to {$target}.");
-            }
+            $this->filesystem->relativeSymlink($target, $link);
         }
 
         file_put_contents("{$contentDirPath}index.php", "<?php\n// Silence is golden.\n");

--- a/src/Task/SymlinkVipGoDir.php
+++ b/src/Task/SymlinkVipGoDir.php
@@ -102,8 +102,9 @@ final class SymlinkVipGoDir implements Task
                 continue;
             }
 
-            $success = $this->filesystem->relativeSymlink($target, $link);
-            !$success && $io->commentLine('[!] Relative symlink for ' . $link . ' to ' . $target . ' failed.');
+            if (!$this->filesystem->relativeSymlink($target, $link)) {
+                $io->errorLine("Failed creating relative symlink for {$link} to {$target}.");
+            }
         }
 
         file_put_contents("{$contentDirPath}index.php", "<?php\n// Silence is golden.\n");

--- a/src/Task/SymlinkVipGoDir.php
+++ b/src/Task/SymlinkVipGoDir.php
@@ -58,6 +58,7 @@ final class SymlinkVipGoDir implements Task
 
     /**
      * @param TaskConfig $taskConfig
+     *
      * @return bool
      */
     public function enabled(TaskConfig $taskConfig): bool
@@ -86,25 +87,23 @@ final class SymlinkVipGoDir implements Task
             $this->directories->vipMuPluginsDir() => "{$contentDirPath}/mu-plugins",
         ];
         foreach ($this->directories->toArray() as $dirPath) {
-            $map[$dirPath] =  "{$contentDirPath}/" . basename($dirPath);
+            $map[$dirPath] = "{$contentDirPath}/" . basename($dirPath);
         }
 
         $isWindows = Platform::isWindows();
 
         foreach ($map as $target => $link) {
-            if (is_dir($link)) {
-                $this->filesystem->removeDirectory($link);
-            }
-
+            $this->filesystem->removeDirectory($link);
             $this->filesystem->ensureDirectoryExists($target);
-            $this->filesystem->normalizePath($link);
+            $link = $this->filesystem->normalizePath($link);
 
             if ($isWindows) {
                 $this->filesystem->junction($target, $link);
                 continue;
             }
 
-            $this->filesystem->relativeSymlink($target, $link);
+            $success = $this->filesystem->relativeSymlink($target, $link);
+            !$success && $io->commentLine('[!] Relative symlink for ' . $link . ' to ' . $target . ' failed.');
         }
 
         file_put_contents("{$contentDirPath}index.php", "<?php\n// Silence is golden.\n");

--- a/src/Utils/HttpClient.php
+++ b/src/Utils/HttpClient.php
@@ -81,7 +81,6 @@ class HttpClient
 
             $result = null;
             if ($this->client instanceof HttpDownloader) {
-                /** @var Response $response */
                 $response = $this->client->get($url, $options);
                 $statusCode = $response->getStatusCode();
                 if ($statusCode > 199 && $statusCode < 300) {


### PR DESCRIPTION
* **Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines

* **What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

This pull request contains various improvments on the `SymlinkVipGoDir`:

> Remove is_dir-check which is not save enough to rely on for symlinked directories.

The [`Filesystem::removeDirectory($directory)`](https://github.com/composer/composer/blob/2.0/src/Composer/Util/Filesystem.php#L97) shouldn't only be used when `is_dir()` returns `true`. In some cases, like symlinks in Apache which are not configured correctly, this function will return `false`, eventho there is a directory. To have a clean run on every `composer vip --local` we need to ensure, that symlinks are set correctly.

It is saver to use this method always. It has internally all checks for `is_link` , `is_dir` and even `isJunction()` to support Windows NTFS Junction.

> Fix missing assigment for normalizePath on $link.

In run-method, the `Filesystem::normalizePath($link)` was called, but the return value was never assigned back to `$link`. In the end, the call did nothing change.

> Add note for failing relativeSymlink.

Since i had a really hard time to figure out _what_ failed (Symlinks were not created because of `is_dir()` and missing `Filesystem::removeDirectory($directory)`), it would be nice to have in future at least for failing parts, like symlinks, a bit more context about. Sadly [`Filesystem::relativeSymlink($target, $link)](https://github.com/composer/composer/blob/2.0/src/Composer/Util/Filesystem.php#L598) changes internally those values to work with, but does not expose anything to outside.

* **What is the current behavior?** (You can also link to an open issue here)

Creating of symlinks after switching a system - but keeping old code - failed silently and broke the site.

* **What is the new behavior (if this is a feature change)?**

Switching between different systems now works smoother, because we can ensure that symlinks/junctions are created correctly on each run.

* **Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No.

* **Other information**:

Happy weekend! ☕ 🍷 