### PR TITLE
Support autoloading non-standard multifile MU plugins

### DIFF
--- a/src/Task/GenerateProductionAutoload.php
+++ b/src/Task/GenerateProductionAutoload.php
@@ -146,7 +146,7 @@ final class GenerateProductionAutoload implements Task
             $content = preg_replace('~\$vendorDir(?:\s*=\s*)[^;]+;~', $vendorDir, $content, 1);
             $content = preg_replace('~\$baseDir(?:\s*=\s*)[^;]+;~', $baseDir, $content ?: '', 1);
             $content = preg_replace(
-                '~\$baseDir\s*\.\s*\'/' . $vipDirBase . '/(plugins|themes)/~',
+                '~\$baseDir\s*\.\s*\'/' . $vipDirBase . '/(client-mu-plugins|plugins|themes)/~',
                 'WP_CONTENT_DIR . \'/$1/',
                 $content ?: ''
             );


### PR DESCRIPTION
This PR extends the autoloader replacement regex to include replacing paths to the `client-mu-plugins`, to support the autoloading of files within packages of type "wordpress-muplugin".

Fixes #8 