### PR TITLE
Config.php // PHP 8.1 support

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -193,7 +193,7 @@ final class Config implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetExists($offset)
+    public function offsetExists($offset): bool
     {
         return $this->offsetGet($offset) !== null;
     }
@@ -202,6 +202,7 @@ final class Config implements \ArrayAccess
      * @param mixed $offset
      * @return mixed
      */
+    #[\ReturnTypeWillChange]
     public function offsetGet($offset)
     {
         if (!is_string($offset) || !$offset) {
@@ -225,7 +226,7 @@ final class Config implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetSet($offset, $value)
+    public function offsetSet($offset, $value): void
     {
         throw new \BadMethodCallException(
             sprintf(
@@ -239,7 +240,7 @@ final class Config implements \ArrayAccess
     /**
      * @inheritdoc
      */
-    public function offsetUnset($offset)
+    public function offsetUnset($offset): void
     {
         throw new \BadMethodCallException(
             sprintf(


### PR DESCRIPTION
Signed-off-by: Christian Leucht <3417446+Chrico@users.noreply.github.com>

**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

`ArrayAccess` has changed with PHP 8.1 and we need to add return types and `#[\ReturnTypeWillChange]` to have support for PHP 7.x and PHP 8.x

**What is the current behavior?** (You can also link to an open issue here)

It produces a Deprecation Notice".

**What is the new behavior (if this is a feature change)?**

Deprecation Notice should be gone with the addition of return types and `#[\ReturnTypeWillChange]` .