### PR TITLE
Support sunrise and pre-config VIP MU plugins "requires"

### DIFF
--- a/src/Task/Factory.php
+++ b/src/Task/Factory.php
@@ -96,6 +96,7 @@ class Factory
             DownloadVipGoMuPlugins::class,
             function (): DownloadVipGoMuPlugins {
                 return new DownloadVipGoMuPlugins(
+                    $this->factory->config(),
                     $this->factory->vipDirectories(),
                     $this->factory->filesystem()
                 );

--- a/src/Task/SymlinkVipGoDir.php
+++ b/src/Task/SymlinkVipGoDir.php
@@ -56,7 +56,6 @@ final class SymlinkVipGoDir implements Task
         $io->commentLine("Symlinking content to {$contentDirPath}...");
 
         $this->filesystem->ensureDirectoryExists($contentDirPath);
-        $this->filesystem->emptyDirectory($contentDirPath);
 
         $map = [
             $uploadsPath => "{$contentDirPath}/{$uploadsDir}",
@@ -69,7 +68,7 @@ final class SymlinkVipGoDir implements Task
         $isWindows = Platform::isWindows();
 
         foreach ($map as $target => $link) {
-            $this->filesystem->removeDirectory($link);
+            $this->filesystem->remove($link);
             $this->filesystem->ensureDirectoryExists($target);
             $link = $this->filesystem->normalizePath($link);
 


### PR DESCRIPTION
**Please check if the PR fulfills these requirements**
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)


**What kind of change does this PR introduce?** (Bug fix, feature, docs update, ...)

Feature

**What is the current behavior?** (You can also link to an open issue here)

- sunrise.php is not supported locally (when not using VIP local dev env), see https://docs.wpvip.com/wordpress-on-vip/multisites/sunrise-php/#h-configuration-for-local-development
- pre-config fles are not loaded locally (when not using VIP local dev env), see #10 

**What is the new behavior (if this is a feature change)?**

- sunrise.php supported locally
- pre-config fles are loaded locally


**Does this PR introduce a breaking change?** (What changes might users need to make in their application due to this PR?)

No

**Other information**:

There's a refactoring of the `UpdateLocalWpConfigFile` class, because to handle tis taks the `run()` method became too big and PHPCS complained. So I split it in two.
