### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/Command.php
+++ b/src/Command.php
@@ -213,7 +213,7 @@ class Command extends BaseCommand
      * @param bool|null $default
      * @return mixed
      */
-    private function optionValue(InputInterface $input, string $option, bool $default = null): mixed
+    private function optionValue(InputInterface $input, string $option, ?bool $default = null): mixed
     {
         if (!$input->hasOption($option)) {
             return $default;

--- a/src/Git/GitProcess.php
+++ b/src/Git/GitProcess.php
@@ -31,8 +31,8 @@ class GitProcess
      */
     public function __construct(
         private Io $io,
-        string $workingDir = null,
-        ProcessExecutor $executor = null
+        ?string $workingDir = null,
+        ?ProcessExecutor $executor = null
     ) {
 
         $cwd = $workingDir ?? getcwd();

--- a/src/Git/VipGit.php
+++ b/src/Git/VipGit.php
@@ -48,7 +48,7 @@ class VipGit
      * @param string|null $branch
      * @return bool
      */
-    public function push(string $url = null, string $branch = null): bool
+    public function push(?string $url = null, ?string $branch = null): bool
     {
         return $this->syncAndPush(true, $url, $branch);
     }
@@ -58,7 +58,7 @@ class VipGit
      * @param string|null $branch
      * @return bool
      */
-    public function sync(string $url = null, string $branch = null): bool
+    public function sync(?string $url = null, ?string $branch = null): bool
     {
         return $this->syncAndPush(false, $url, $branch);
     }
@@ -89,7 +89,7 @@ class VipGit
      *
      * @psalm-assert GitProcess $this->git
      */
-    private function syncAndPush(bool $push, string $url = null, string $branch = null): bool
+    private function syncAndPush(bool $push, ?string $url = null, ?string $branch = null): bool
     {
         $message = 'Starting Git sync';
         $push or $message .= ' (NO push will happen)';
@@ -139,7 +139,7 @@ class VipGit
      * @param string|null $customBranch
      * @return array{non-empty-string,non-empty-string}|array{null,null}
      */
-    private function init(string $customUrl = null, string $customBranch = null): array
+    private function init(?string $customUrl = null, ?string $customBranch = null): array
     {
         /**
          * @vase string|null $httpsUrl
@@ -306,7 +306,7 @@ class VipGit
      * @param string|null $customUrl
      * @return array{non-empty-string,non-empty-string}|array{null,null}
      */
-    private function gitUrls(string $customUrl = null): array
+    private function gitUrls(?string $customUrl = null): array
     {
         /** @var string $url */
         $url = $customUrl ?? $this->gitConfig[Config::GIT_URL_KEY];


### PR DESCRIPTION
## Please check if the PR fulfills these requirements
- [x] The commit message follows our guidelines
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)


## What kind of change does this PR introduce? (Bug fix, feature, docs update, ...)

PHP 8.4 deprecates **implicitly nullable types**. PHP applications are recommended to explicitly declare the type as `nullable`. All type declarations that have a default value of `null`, but without declaring `null` in the type declaration, emit a deprecation notice.

## What is the current behavior? (You can also link to an open issue here)

It produces a deprecation notice.

## What is the new behavior (if this is a feature change)?

The deprecation notice should be gone.

## Other information
https://php.watch/versions/8.4/implicitly-marking-parameter-type-nullable-deprecated